### PR TITLE
Change: Text for main page and import from fakturabank

### DIFF
--- a/modules/invoicein/view/list.php
+++ b/modules/invoicein/view/list.php
@@ -31,7 +31,7 @@ print $_lib['sess']->doctype; ?>
 
 
 <h2>
-<? if($_lib['sess']->get_person('FakturabankImportInvoiceAccess')) { ?><a href="<? print $_lib['sess']->dispatch ?>t=fakturabank.listincoming">Importer fakturaer med status approved fra Fakturabank</a><br> <? } ?>
+<? if($_lib['sess']->get_person('FakturabankImportInvoiceAccess')) { ?><a href="<? print $_lib['sess']->dispatch ?>t=fakturabank.listincoming">Importer fakturaer med status regnskapbilag fra Fakturabank</a><br> <? } ?>
 <a href="<? print $_lib['sess']->dispatch ?>t=fakturabank.invoicereconciliationlist">Oppsett av koblinger mellom avstemmings&aring;rsaker og kontoer</a>
 </h2>
 

--- a/modules/lodo/view/main.php
+++ b/modules/lodo/view/main.php
@@ -24,9 +24,12 @@ print $_lib['sess']->doctype ?>
 
 <? includeinc('top') ?>
 <? includeinc('left') ?>
+<? $send_scan_to_email = str_replace(" MVA","",$_lib['sess']->get_companydef('OrgNumber')) . "@scanning.fakturabank.no"; ?>
 
-  <h2 class="groupheader">Send dine innscannede innkommende pdf bilag til: <a href="mailto:<? print str_replace(" MVA","",$_lib['sess']->get_companydef('OrgNumber')) ?>@scanning.fakturabank.no"><? print str_replace(" MVA","",$_lib['sess']->get_companydef('OrgNumber')) ?>@scanning.fakturabank.no</a> s&aring; vil de bli punchet og lagt klar for automatisk bilagsf&oslash;ring i fakturabank</h2>
-<h2 class="groupheader">Forside</h2>
+  <h2 class="groupheader">Vil du bruke fakturaBank? Elektronisk oppbevaring av dine dokumenter.</h2>
+  <h2 class="groupheader">Skann og send til: <a href="mailto:<? print $send_scan_to_email; ?>"><? print $send_scan_to_email; ?></a></h2>
+
+  <h2 class="groupheader">Forside</h2>
 
 <h3><a href="http://sourceforge.net/tracker2/?func=add&group_id=167033&atid=841330">Rapporter feil</a></h3>
 


### PR DESCRIPTION
Changed text for status of invoice we download from fakturabank
and the text on the main page for scanning.fakturabank.no

https://trello.com/c/ShPa9JPN/560-lodo-front-page-bad-texting-md-text-fixes
https://trello.com/c/slAJaDVm/558-lodo-import-invoices-with-status-approved-md-text-fixes
