### PR TITLE
Invoiceout double send token error

### DIFF
--- a/modules/oauth/model/oauth.class.php
+++ b/modules/oauth/model/oauth.class.php
@@ -85,6 +85,7 @@ class lodo_oauth {
       // get code
       $authorize_url = $this->client->getAuthenticationUrl($this->generate_server_url() . $this->authorize_url, $this->callback_url);
       header("Location: " . $authorize_url);
+      die();
     }
     // if we have the code, get the token
     else {


### PR DESCRIPTION
A die() statement was needed after redirecting to oauth authorize url to stop further code execution and not unset some session vars.
