### PR TITLE
Allow regular user to update altinn fields on a locked salary

### DIFF
--- a/inc/javascript.inc.php
+++ b/inc/javascript.inc.php
@@ -431,4 +431,27 @@ function allowOnlyCreditOrDebit(element, credit_or_debit) {
   onCurrencyRateChange(conv_rate);
 }
 
+/*
+ * OnClick action for locking salaries.
+ * Checks if all Altinn fields are punched in and warns user which ones aren't
+ * with the message that is passed as a parameter.
+ * Other params are inital values of fields on page load.
+ * Used in salary/edit view.
+ */
+function checkIfAltinnFieldsSetAndConfirm(message, shift_type, work_time_scheme, type_of_employment, occupation_id, subcompany_id, altinn_date_set) {
+
+  var errors = "";
+  // if any of the values are not set add to the warning message
+  if (shift_type == "") errors += "- Skifttype\n";
+  if (work_time_scheme == "") errors += "- Arbeidstid\n";
+  if (type_of_employment == "") errors += "- Ansettelsestype\n";
+  if (occupation_id == 0) errors += "- Yrke\n";
+  if (subcompany_id == 0) errors += "- Ansatt ved\n";
+  if (!altinn_date_set) errors += "- Altinndato\n";
+  if (errors != "") errors = "Ikke valgt:\n" + errors;
+  message = errors + message;
+
+  return confirm(message);
+}
+
 </script>

--- a/modules/salary/view/edit.php
+++ b/modules/salary/view/edit.php
@@ -495,58 +495,35 @@ $formname = "salaryUpdate";
     if($_lib['sess']->get_person('AccessLevel') >= 2)
     {
         print $_lib['form3']->hidden(array('name'=>'fieldcount', 'value'=>$counter));
-        if(!$head->Period)
+        if(!$head->Period || $accounting->is_valid_accountperiod($head->Period, $_lib['sess']->get_person('AccessLevel')))
         {
             ?>
         <tr>
-          <td>
+          <td colspan='14'>
           <?php
             if(!$head->LockedBy || $_lib['sess']->get_person('AccessLevel') >= 4)
             {
               echo '<input type="submit" name="action_salary_journal" value="Lagre (S)" accesskey="S" align="right" />';
+              echo '<input type="submit" name="action_salary_update_altinn_fields" value="Lagre altinn felter" align="right" />';
             }
 
             echo '<input type="submit" name="action_salary_internal" value="Lagre internkommentar(S)" accesskey="S" align="right" />';
             echo '<input type="submit" name="action_salary_update_extra" value="Updater kontoinformasjon" accesskey="U" align="right" />';
+            echo '<input type="submit" name="action_altindato_update" value="Lagre altinndato" align="right" ' . (($altinndato_set) ? 'disabled' : '') . '/>';
           ?>
 
           </td>
+        </tr>
         <tr>
           <td>
           <?php
-            if(!$head->LockedBy) echo '<input type="submit" name="action_salary_lock" value="L&aring;s (L)" accesskey="L" />';
-            else echo "L&aring;st av " . $head->LockedBy . " " . $head->LockedDate;
+            $is_altinn_date_set = (is_null($head->ActualPayDate) || $head->ActualPayDate == '' || $head->ActualPayDate == '0000-00-00') ? 'false' : 'true';
+            $altinn_arguments = "'$head->ShiftType', '$head->WorkTimeScheme', '$head->TypeOfEmployment', $head->OccupationID, $head->SubcompanyID, $is_altinn_date_set";
+            if(!$head->LockedBy) echo '<input type="submit" name="action_salary_lock" value="L&aring;s (L)" accesskey="L" onclick="return checkIfAltinnFieldsSetAndConfirm(\'Er du siker?\', '.$altinn_arguments.');" />';
           ?>
           </td>
         </tr>
         <?
-        }
-        elseif($accounting->is_valid_accountperiod($head->Period, $_lib['sess']->get_person('AccessLevel')))
-        {
-          ?>
-        <tr>
-          <td colspan="14">
-                <?php
-
-                  if(!$head->LockedBy || $_lib['sess']->get_person('AccessLevel') >= 4)
-                  {
-                    echo '<input type="submit" name="action_salary_journal" value="Lagre (S)" accesskey="S" align="right" /><br />';
-                  }
-
-                  echo '<input type="submit" name="action_salary_internal" value="Lagre internkommentar(S)" accesskey="S" align="right" />';
-                  echo '<input type="submit" name="action_salary_update_extra" value="Updater kontoinformasjon" accesskey="U" align="right" />';
-                  echo '<input type="submit" name="action_altindato_update" value="Lagre altinndato" align="right" ' . (($altinndato_set) ? 'disabled' : '') . '/>';
-            ?>
-          </td>
-        </tr>
-        <tr>
-          <td>
-          <?
-             if(!$head->LockedBy) echo '<input type="submit" name="action_salary_lock" value="L&aring;s (L)" accesskey="L" />';
-          ?>
-          </td>
-        </tr>
-            <?
         }
         else
         {

--- a/modules/salary/view/record.inc
+++ b/modules/salary/view/record.inc
@@ -1043,6 +1043,16 @@ elseif($_lib['input']->getProperty('action_altindato_update')) {
     $_lib['db']->db_query($query_update_altinn_date);
   }
 }
+elseif($_lib['input']->getProperty('action_salary_update_altinn_fields')) {
+  $tables['salary'] = 'SalaryID';
+  $args['salary_ShiftType_' . $SalaryID]        = $_POST['salary_ShiftType_' . $SalaryID];
+  $args['salary_WorkTimeScheme_' . $SalaryID]   = $_POST['salary_WorkTimeScheme_' . $SalaryID];
+  $args['salary_TypeOfEmployment_' . $SalaryID] = $_POST['salary_TypeOfEmployment_' . $SalaryID];
+  $args['salary_OccupationID_' . $SalaryID]     = $_POST['salary_OccupationID_' . $SalaryID];
+  $args['salary_SubcompanyID_' . $SalaryID]     = $_POST['salary_SubcompanyID_' . $SalaryID];
+  $args['salary_ActualPayDate_' . $SalaryID]    = $_POST['salary_ActualPayDate_' . $SalaryID];
+  $_lib['storage']->db_update_multi_table($args, $tables);
+}
 
 function getAltinnReportedDateTime($SalaryID) {
   global $_lib;


### PR DESCRIPTION
Closes #69
Now a regular user can update altinn fields after the salary is locked.
After it is locked a new action button will appear instead of save and it saves only the altinn fields.
