### PR TITLE
Fix: Temporary redirect back url in session

### DIFF
--- a/modules/bank/view/fakturabankimport.php
+++ b/modules/bank/view/fakturabankimport.php
@@ -1,4 +1,5 @@
 <?
+session_start();
 # $Id: import.php,v 1.16 2005/10/24 11:50:24 svenn Exp $ account_import.php,v 1.3 2001/11/20 17:55:12 thomasek Exp $
 # Based on EasyComposer technology
 # Copyright Thomas Ekdahl, 1994-2005, thomas@ekdahl.no, http://www.ekdahl.no

--- a/modules/fakturabank/view/listincoming.php
+++ b/modules/fakturabank/view/listincoming.php
@@ -11,11 +11,12 @@ includelogic('orgnumberlookup/orgnumberlookup');
 $accounting = new accounting();
 
 require_once "record.inc";
-$fb         = new lodo_fakturabank_fakturabank();
-$InvoicesO  = $fb->incoming();
 
 $tmp_redirect_url = "$_SETUP[OAUTH_PROTOCOL]://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
 $_SESSION['oauth_tmp_redirect_back_url'] = $tmp_redirect_url;
+
+$fb         = new lodo_fakturabank_fakturabank();
+$InvoicesO  = $fb->incoming();
 
 print $_lib['sess']->doctype; ?>
 <head>

--- a/modules/fakturabank/view/listoutgoing.php
+++ b/modules/fakturabank/view/listoutgoing.php
@@ -9,11 +9,11 @@ includelogic('fakturabank/fakturabank');
 $accounting = new accounting();
 require_once "record.inc";
 
-$fb         = new lodo_fakturabank_fakturabank();
-$InvoicesO  = $fb->outgoing();
-
 $tmp_redirect_url = "$_SETUP[OAUTH_PROTOCOL]://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
 $_SESSION['oauth_tmp_redirect_back_url'] = $tmp_redirect_url;
+
+$fb         = new lodo_fakturabank_fakturabank();
+$InvoicesO  = $fb->outgoing();
 
 print $_lib['sess']->doctype; ?>
 <head>


### PR DESCRIPTION
Fixes: When session is clean and token not set, some oauth requests do not set the redirect back url correctly and get redirected to main page after.
