### PR TITLE
Fix: Employee validation

### DIFF
--- a/modules/accountplan/view/record.inc
+++ b/modules/accountplan/view/record.inc
@@ -5,6 +5,8 @@ includelogic("accountplan/scheme");
 function validate_employee($employee) {
     global $_lib;
 
+    if(!$employee->AccountPlanID) return null;
+    
     $errors = array();
     if(empty($employee->FirstName)) {
         $errors[] = "Fornavn kan ikke v&aelig;re blank.";


### PR DESCRIPTION
The employee page used to crash in case new employee was created, due to validation.
