### PR TITLE
Postmotpost optimization vol 1

### DIFF
--- a/modules/benchmark/model/benchmark.class.php
+++ b/modules/benchmark/model/benchmark.class.php
@@ -1,0 +1,77 @@
+<?
+
+// Bencmarking class
+//
+// Usage:
+//
+// $bm = new benchmark("benchmark title"); // create new benchmark object
+// $bm->start("benchmark start message");  // start the bencmark
+// $bm->add("checkpoint message");         // add as many checkpoints as needed
+// $bm->stop("checkpoint message");        // stop the benchmark
+// $bm->var_dump_benchmark();              // print the results
+
+class benchmark {
+
+  public $_title = '';
+  public $_timings = array();
+  public $_start_time = 0.0;
+  public $_last_time = 0.0;
+  public $_stop_time = 0.0;
+
+  function __construct($title = '') {
+    $this->_title = $title;
+    $this->_timings = array();
+    $this->_start_time = 0.0;
+    $this->_last_time = 0.0;
+    $this->_stop_time = 0.0;
+  }
+
+  function start($message = '') {
+    $this->_start_time = microtime(true);
+    $this->_last_time = $this->_start_time;
+    $this->_timings[] = array(
+                        'time_from_start' => 0,
+                        'time_from_last' => 0,
+                        'message' => $message
+                       );
+  }
+
+  function add($message) {
+    $time_now = microtime(true);
+    $time_from_start = self::time_from_start($time_now);
+    $time_from_last = self::time_from_last($time_now);
+    $this->_last_time = $time_now;
+    $this->_timings[] = array(
+                        'time_from_start' => $time_from_start,
+                        'time_from_last' => $time_from_last,
+                        'message' => $message
+                       );
+  }
+
+  function time_from_start($timestamp) {
+    return $timestamp - $this->_start_time;
+  }
+
+  function time_from_last($timestamp) {
+    return $timestamp - $this->_last_time;
+  }
+
+  function stop($message = '') {
+    self::add($message);
+    $this->_stop_time = $this->_last_time;
+  }
+
+  function var_dump_benchmark() {
+    var_dump("BENCHMARK DUMP FOR: ". $this->_title);
+    var_dump("STARTED: ". sprintf('%012.23f', $this->_start_time));
+    $total_time = $this->_stop_time - $this->_start_time;
+    foreach ($this->_timings as $timing) {
+      $percent = ($timing['time_from_last'] / $total_time) * 100.0;
+      var_dump("STARTED: +". sprintf('%012.23f', $timing['time_from_start']) ." LASTED: ". sprintf('%012.23f', $timing['time_from_last']) ." PERCENTAGE OF TOTAL: ". sprintf('%02.4f', $percent) ."% MESSAGE: ". $timing['message']);
+    }
+    var_dump("STOPPED: ". sprintf('%012.23f', $this->_stop_time));
+    var_dump("BENCHMARK LASTED: ". sprintf('%04.23f', $total_time));
+  }
+}
+
+?>


### PR DESCRIPTION
# postmotpost.list, view

before optimization most time spent on: building voucher query -> building voucher query(if onlyAccountPlanID)
after optimization vol 1 most time spent on: building voucher query -> building voucher query(if onlyAccountPlanID) and before query exec -> after query exec

before:

| # | clog action time(s) | page load time(s) |
| --- | --- | --- |
| 1st | 35.37140488624572753906250 | 35.43775010108947753906250 |
| 2nd | 35.30465197563171386718750 | 35.36683511734008789062500 |
| 3rd | 37.70465683937072753906250 | 37.76648998260498046875000 |
| 4th | 34.96849083900451660156250 | 35.03258800506591796875000 |
| 5th | 34.50547599792480468750000 | 34.57412505149841308593750 |
| --- | --- | --- |
| avg | **35.57093610763549804687500** | **35.63555765151977539062500** |

after:

| # | clog action 1 time(s) | clog action 2 time(s) | total(s) | page load time(s) |
| --- | --- | --- | --- | --- |
| 1st | 1.50650787353515625000000 | 1.55847597122192382812500 |  | 3.12847018241882324218750 |
| 2nd | 1.56201791763305664062500 | 1.56626892089843750000000 |  | 3.19173097610473632812500 |
| 3rd | 1.52724504470825195312500 | 1.60383820533752441406250 |  | 3.19354796409606933593750 |
| 4th | 1.54052901268005371093750 | 1.57825803756713867187500 |  | 3.17743206024169921875000 |
| 5th | 1.50865912437438964843750 | 1.58135199546813964843750 |  | 3.15360713005065917968750 |
| --- | --- | --- | --- | --- |
| avg | 1.52899179458618164062500 | 1.57763862609863281250000 | **3.10663042068481445312500** | **3.16895766258239746093750** |

speed up after optimization vol 1:

|  | times faster |
| --- | --- |
| most time spent on actions | **11.45** |
| total page load | **11.24** |
# postmotpost.list, show all

before optimization most time spent on: before query exec -> after query exec
after optimization vol 1 most time spent on: before query exec -> after query exec

before:

| # | clog action time(s) | page load time(s) |
| --- | --- | --- |
| 1st | 38.60741686820983886718750 | 39.10471296310424804687500 |
| 2nd | 38.45276498794555664062500 | 38.92846298217773437500000 |
| 3rd | 39.58899307250976562500000 | 40.12067198753356933593750 |
| 4th | 38.79454398155212402343750 | 39.28111600875854492187500 |
| 5th | 39.88341307640075683593750 | 40.46088099479675292968750 |
| --- | --- | --- |
| avg | **39.06542639732360839843750** | **39.57916898727416992187500** |

after:

| # | clog action time(s) | page load time(s) |
| --- | --- | --- |
| 1st | 2.26496911048889160156250 | 2.33866214752197265625000 |
| 2nd | 2.14841103553771972656250 | 2.21811079978942871093750 |
| 3rd | 2.09995603561401367187500 | 2.16857004165649414062500 |
| 4th | 2.10172986984252929687500 | 2.17367887496948242187500 |
| 5th | 2.11885499954223632812500 | 2.18879914283752441406250 |
| --- | --- | --- |
| avg | **2.14678421020507812500000** | **2.21756420135498046875000** |

speed up after optimization vol 1:

|  | times faster |
| --- | --- |
| most time spent on actions | **18.20** |
| total page load | **17.85** |
# postmotpost.list, open all

before optimization most time spent on: before query exec -> after query exec
after optimization vol 1 most time spant on: before query exec -> after query exec

before:

| # | clog action time(s) | page load time(s) |
| --- | --- | --- |
| 1st | 38.16425299644470214843750 | 52.36499500274658203125000 |
| 2nd | 37.56235289573669433593750 | 51.10287308692932128906250 |
| 3rd | 37.67407512664794921875000 | 50.89010620117187500000000 |
| 4th | 38.66418886184692382812500 | 52.36215019226074218750000 |
| 5th | 36.97571301460266113281250 | 50.11367607116699218750000 |
| --- | --- | --- |
| avg | **37.80811657905578613281250** | **51.36676011085510253906250** |

after:

| # | clog action time(s) | page load time(s) | extra time wasted on openAllPostsForOpenPeriods() |
| --- | --- | --- | --- |
| 1st | 5.30793404579162597656250 | 15.19143414497375488281250 | 9.43058896064758300781250 |
| 2nd | 5.08112788200378417968750 | 14.57760596275329589843750 | 9.01406192779541015625000 |
| 3rd | 5.67704701423645019531250 | 16.40879011154174804687500 | 10.28707003593444824218750 |
| 4th | 5.36808586120605468750000 | 15.18092703819274902343750 | 9.35380697250366210937500 |
| 5th | 5.31870889663696289062500 | 15.47208690643310546875000 | 9.69601106643676757812500 |
| --- | --- | --- | --- |
| avg | **5.35058073997497558593750** | **15.36616883277893066406250** | 9.55630779266357421875000 |

speed up after optimization vol 1:

|  | times faster |
| --- | --- |
| most time spent on actions | **7.07** |
| total page load | **3.34** |
# postmotpost.list, close all

before optimization most time spent on: before query exec -> after query exec
after optimization vol 1 most time spent on: before query exec -> after query exec x 2

before:

| # | clog action 1 time(s) | clog action 2 time(s) | total(s) | page load time(s) |
| --- | --- | --- | --- | --- |
| 1st | 38.46128606796264648437500 | 35.57435393333435058593750 |  | 74.64534091949462890625000 |
| 2nd | 37.88180613517761230468750 | 35.19870400428771972656250 |  | 73.73748803138732910156250 |
| 3rd | 37.99718117713928222656250 | 35.54508900642395019531250 |  | 74.16536092758178710937500 |
| 4th | 38.50964903831481933593750 | 34.72278785705566406250000 |  | 73.83652400970458984375000 |
| 5th | 38.21387195587158203125000 | 35.80626916885375976562500 |  | 74.60718202590942382812500 |
| --- | --- | --- | --- | --- |
| avg | 38.21275887489318847656250 | 35.36944079399108886718750 | **73.58219966888427734375** | **74.19837918281555175781250** |

after:

| # | clog action 1 time(s) | clog action 2 time(s) | total(s) | page load time(s) |
| --- | --- | --- | --- | --- |
| 1st | 5.09379506111145019531250 | 2.03149294853210449218750 |  | 7.68232202529907226562500 |
| 2nd | 5.11423087120056152343750 | 2.22750592231750488281250 |  | 7.95288515090942382812500 |
| 3rd | 5.32624292373657226562500 | 2.14673614501953125000000 |  | 8.05098009109497070312500 |
| 4th | 5.25391197204589843750000 | 2.10866904258728027343750 |  | 7.94395112991333007812500 |
| 5th | 5.37269902229309082031250 | 2.10054588317871093750000 |  | 8.04724502563476562500000 |
| --- | --- | --- | --- | --- |
| avg | 5.23217597007751464843750 | 2.12298998832702636718750 | **7.355165958404541015625** | **7.93547668457031250000000** |

speed up after optimization vol 1:

|  | times faster |
| --- | --- |
| most time spent on actions | **10.00** |
| total page load | **9.35** |
