### PR TITLE
Fix for suspicious vouchers in verification report

### DIFF
--- a/modules/report/view/verify_consistency.php
+++ b/modules/report/view/verify_consistency.php
@@ -540,8 +540,7 @@ FROM
 WHERE
   V1.Active = 1
   AND
-
-  (V1.VatID != 0
+  ((V1.VatID != 0
   AND V1.Vat > 0.0
   AND V1.AmountIn + V1.AmountOut > 0.1
   AND (
@@ -555,7 +554,7 @@ WHERE
       OR V2.AmountOut != V3.AmountIn)
   ))
   OR
-  (VAT.Percent != V1.Vat)
+  (VAT.Percent != V1.Vat))
 ";
 
          $res = $_lib['db']->db_query($query);


### PR DESCRIPTION
Closes #254 

Run this query to see what the issue was:

``` sql
SELECT V1.VoucherID AS V1VoucherID,
       V1.AutomaticVatVoucherID AS V1AutomaticVatVoucherID,
       V1.VatID AS V1VatID,
       V1.VoucherDate AS V1VoucherDate,
       V1.Active AS V1Active,
       V1.Vat AS V1Vat,
       V1.AmountIn AS V1AmountIn,
       V1.AmountOut AS V1AmountOut,
       V2.VoucherID AS V2VoucherID,
       V2.Active AS V2Active,
       V2.AutomaticVatVoucherID AS V2AutomaticVatVoucherID,
       V2.AmountIn AS V2AmountIn,
       V2.AmountOut AS V2AmountOut,
       V3.VoucherID AS V3VoucherID,
       V3.Active AS V3Active,
       V3.AutomaticVatVoucherID AS V3AutomaticVatVoucherID,
       V3.AmountIn AS V3AmountIn,
       V3.AmountOut AS V3AmountOut,
       VAT.VatID AS VATVatID,
       VAT.ValidFrom AS VATValidFrom,
       VAT.ValidTo AS VATValidTo,
       VAT.Percent AS VATPercent
FROM
  voucher AS V1
  LEFT JOIN voucher AS V2 ON (V2.VoucherID = V1.AutomaticVatVoucherID)
  LEFT JOIN voucher AS V3 ON (V3.VoucherID = V2.AutomaticVatVoucherID)
  LEFT JOIN vat AS VAT ON ( VAT.VatID = V1.VatID AND VAT.ValidFrom <= V1.VoucherDate AND VAT.ValidTo >= V1.VoucherDate )
WHERE
  V1.Active = 1
  AND
  (
    V1.VatID != 0
    AND V1.Vat > 0.0
    AND V1.AmountIn + V1.AmountOut > 0.1
    AND (( V2.VoucherID IS NULL OR V2.Active = 0 ) OR ( V3.VoucherID IS NULL OR V3.Active = 0 ) OR ( V2.AmountIn != V3.AmountOut OR V2.AmountOut != V3.AmountIn ))
  )
  OR ( VAT.Percent != V1.Vat )
```

The issue pertains to the WHERE part of the query failing when the `( VAT.Percent != V1.Vat )` part is true and the `V1.Active = 1` part is false. Meaning that the entire WHERE expression will resolve as true. Since we do not want to show the result for inactive vouchers, we should make the AND take top priority (since and and or take same priority and are just executed from left to right). That is why we need a set of brackets around the entire part that comes after the top AND.
