### PR TITLE
Optimization on postmotpost volume 2

### DIFF
--- a/modules/benchmark/model/benchmark.class.php
+++ b/modules/benchmark/model/benchmark.class.php
@@ -1,6 +1,6 @@
 <?
 
-// Bencmarking class
+// Benchmarking class
 //
 // Usage:
 //


### PR DESCRIPTION
Closes #221 

# postmotpost.list, view
before:

| # | page load time(s) |
| --- | --- |
| 1st | 3.18394923210144042968750 |
| 2nd | 2.92119884490966796875000 |
| 3rd | 2.99301600456237792968750  |
| 4th | 2.94459414482116699218750 |
| 5th | 3.18218708038330078125000 |
| 6th | 3.23033404350280761718750  |
| 7th | 2.99233698844909667968750 |
| 8th | 3.03036808967590332031250 |
| 9th | 2.96207499504089355468750  |
| 10th | 2.98264503479003906250000 |
| --- | --- |
| avg | **3.04227044582** |

after:

| # | page load time(s) |
| --- | --- |
| 1st | 3.03338813781738281250000 |
| 2nd | 2.99350690841674804687500 |
| 3rd | 3.12582206726074218750000 |
| 4th | 3.16088604927062988281250 |
| 5th | 2.97606086730957031250000 |
| 6th | 2.93806195259094238281250  |
| 7th | 2.97729086875915527343750 |
| 8th | 2.88323903083801269531250 |
| 9th | 2.94597506523132324218750  |
| 10th | 2.89166402816772460937500 |
| --- | --- |
| avg | **2.99258949757** |

speed up after optimization vol 2:

|  | times faster |
| --- | --- |
| total page load | **1.01**(insignificant) |

# postmotpost.list, show all

before:

| # | page load time(s) |
| --- | --- |
| 1st | 6.13803386688232421875000 |
| 2nd | 6.52669501304626464843750 |
| 3rd | 6.01023316383361816406250  |
| 4th | 5.77050900459289550781250 |
| 5th | 5.94212794303894042968750 |
| 6th | 5.59461498260498046875000  |
| 7th | 6.46563696861267089843750 |
| 8th | 5.85781383514404296875000 |
| 9th | 5.89111709594726562500000  |
| 10th | 6.39145207405090332031250 |
| --- | --- |
| avg | **6.05882339478** |

after:

| # | page load time(s) |
| --- | --- |
| 1st | 2.10778689384460449218750 |
| 2nd | 2.13037896156311035156250 |
| 3rd | 2.30800890922546386718750  |
| 4th | 2.09205198287963867187500 |
| 5th | 2.09125304222106933593750 |
| 6th | 2.43255400657653808593750  |
| 7th | 2.11652493476867675781250 |
| 8th | 2.09428715705871582031250 |
| 9th | 2.19562292098999023437500 |
| 10th | 2.12886381149291992187500 |
| --- | --- |
| avg | **2.16973326206** |

speed up after optimization vol 2:

|  | times faster |
| --- | --- |
| total page load | **2.80** |

# postmotpost.list, open all

before:

| # | page load time(s) |
| --- | --- |
| 1st | 16.21876692771911621093750 |
| 2nd | 16.68330788612365722656250 |
| 3rd | 17.58986902236938476562500  |
| 4th | 17.34908294677734375000000 |
| 5th | 15.24082207679748535156250 |
| 6th | 15.21802806854248046875000  |
| 7th | 15.66938686370849609375000 |
| 8th | 16.03187704086303710937500 |
| 9th | 16.58183288574218750000000  |
| 10th | 16.28492498397827148437500 |
| --- | --- |
| avg | **16.2867898703** |

after:

| # | page load time(s) |
| --- | --- |
| 1st | 9.09001803398132324218750 |
| 2nd | 9.63831496238708496093750 |
| 3rd | 9.37757897377014160156250  |
| 4th | 9.09312081336975097656250 |
| 5th | 10.34401321411132812500000 |
| 6th | 9.70650100708007812500000  |
| 7th | 9.86097812652587890625000 |
| 8th | 9.22098803520202636718750 |
| 9th | 10.03351306915283203125000  |
| 10th | 9.45962882041931152343750 |
| --- | --- |
| avg | **9.5824655056** |

speed up after optimization vol 2:

|  | times faster |
| --- | --- |
| total page load | **1.70** |

# postmotpost.list, close all

before:

| # | page load time(s) |
| --- | --- |
| 1st | 8.69693017005920410156250 |
| 2nd | 7.79940509796142578125000 |
| 3rd | 8.54980993270874023437500  |
| 4th | 8.71379709243774414062500 |
| 5th | 8.18055009841918945312500 |
| 6th | 7.72475385665893554687500  |
| 7th | 8.18386292457580566406250 |
| 8th | 8.23620796203613281250000 |
| 9th | 8.04898715019226074218750  |
| 10th | 7.85384702682495117187500 |
| --- | --- |
| avg | **8.19881513119** |

after:

| # | page load time(s) |
| --- | --- |
| 1st | 7.92851805686950683593750 |
| 2nd | 7.80336189270019531250000 |
| 3rd | 7.88915300369262695312500  |
| 4th | 7.84317898750305175781250 |
| 5th | 8.17091393470764160156250 |
| 6th | 8.67033386230468750000000  |
| 7th | 8.65986299514770507812500 |
| 8th | 8.41665196418762207031250 |
| 9th | 8.62878489494323730468750  |
| 10th | 8.20386099815368652343750 |
| --- | --- |
| avg | **8.22146205902** |

speed up after optimization vol 2:

|  | times faster |
| --- | --- |
| total page load | **0.99**(insignificant) |