### PR TITLE
Currency picking on new journal

### DIFF
--- a/inc/javascript.inc.php
+++ b/inc/javascript.inc.php
@@ -241,7 +241,7 @@ function onCurrencyChange(selObj) {
  */
 function journalCurrencyChange(btn, action_url)
 {
-    var wrapper = btn.parentNode;
+    wrapper = btn.parentNode;
 
     var wrapper_children = wrapper.childNodes;
 

--- a/modules/accounting/model/accounting.class.php
+++ b/modules/accounting/model/accounting.class.php
@@ -1408,7 +1408,7 @@ class accounting {
 
             #########################################
             #Update line values
-            $this->update_voucher_line_smart($voucher_input->request('voucher_head_update'), $voucher_input->VoucherIDOld, 'update_voucher_head');
+            $this->update_voucher_line_smart($voucher_input->request('voucher_head_update'), $voucher_input->VoucherIDOld, 'update_voucher_head', $voucher_input->VoucherIsInOrOut);
 
             ########################################
             #oppdatere motkontoer hvis vi har byttet periode
@@ -1605,9 +1605,13 @@ class accounting {
     * @param
     * @return
     */
-    public function correct_journal_balance($fields, $JournalID, $VoucherType) {
+    public function correct_journal_balance($fields, $JournalID, $VoucherType, $new = false) {
         global $_lib;
         #print "<b>Korriger balanse automatisk</b><br>";
+
+        $ForeignConvRate   = $fields['voucher_ForeignConvRate'];
+        $ForeignAmount     = $fields['voucher_ForeignAmount'];
+        $ForeignCurrencyID = $fields['voucher_ForeignCurrencyID'];
 
         #$fields['voucher_KID']         = '';
         $fields['voucher_AutoKID']            = '';#We empty kid
@@ -1685,9 +1689,15 @@ class accounting {
                 #print "correct_journal_balance: new<br>";
                 $fields['voucher_AddedByAutoBalance']   = 1;
                 $fields['voucher_Active']               = 1;
-                $fields['voucher_ForeignConvRate']      = 0;
-                $fields['voucher_ForeignAmount']        = 0;
-                $fields['voucher_ForeignCurrencyID']    = '';
+                if ($new) {
+                  $fields['voucher_ForeignConvRate']      = $ForeignConvRate;
+                  $fields['voucher_ForeignAmount']        = $ForeignAmount;
+                  $fields['voucher_ForeignCurrencyID']    = $ForeignCurrencyID;
+                } else {
+                  $fields['voucher_ForeignConvRate']      = 0;
+                  $fields['voucher_ForeignAmount']        = 0;
+                  $fields['voucher_ForeignCurrencyID']    = '';
+                }
                 #print_r($fields);
                 $VoucherID = $_lib['storage']->db_new_hash($fields, 'voucher');
                 $this->set_accountplan_usednow($fields['voucher_AccountPlanID']);

--- a/modules/bank/model/bank.class.php
+++ b/modules/bank/model/bank.class.php
@@ -1090,7 +1090,7 @@ class framework_logic_bank {
                                     $FBVoucherH['voucher_ForeignConvRate']   = 0;
                                 } else {
                                     $FBVoucherH['voucher_ForeignCurrencyID'] = $rel['Currency'];
-                                    $FBVoucherH['voucher_ForeignAmount']     = $rel['Amount'];
+                                    $FBVoucherH['voucher_ForeignAmount']     = abs($rel['Amount']);
                                     $FBVoucherH['voucher_ForeignConvRate']   = exchange::getConversionRate($rel['Currency']);
                                     $FBVoucherH['voucher_AmountOut']         = exchange::convertToLocal($rel['Currency'], $rel['Amount']);
                                     $FBVoucherH['voucher_AmountIn']          = 0;
@@ -1132,7 +1132,7 @@ class framework_logic_bank {
                                     $FBVoucherH['voucher_ForeignConvRate']   = 0;
                                 } else {
                                     $FBVoucherH['voucher_ForeignCurrencyID'] = $rel['Currency'];
-                                    $FBVoucherH['voucher_ForeignAmount']     = $rel['Amount'];
+                                    $FBVoucherH['voucher_ForeignAmount']     = abs($rel['Amount']);
                                     $FBVoucherH['voucher_ForeignConvRate']   = exchange::getConversionRate($rel['Currency']);
                                     $FBVoucherH['voucher_AmountOut']         = exchange::convertToLocal($rel['Currency'], $rel['Amount']);
                                     $FBVoucherH['voucher_AmountIn']          = 0;
@@ -1239,7 +1239,7 @@ class framework_logic_bank {
                     } else {
                         $amount = $unvoted->AmountIn > 0 ? $unvoted->AmountIn : $unvoted->AmountOut;
                         $VoucherH['voucher_ForeignCurrencyID'] = $unvoted->Currency;
-                        $VoucherH['voucher_ForeignAmount']     = $amount;
+                        $VoucherH['voucher_ForeignAmount']     = abs($amount);
                         $VoucherH['voucher_ForeignConvRate']   = exchange::getConversionRate($unvoted->Currency);
                         $VoucherH['voucher_AmountOut']         = $unvoted->AmountOut > 0 ? exchange::convertToLocal($unvoted->Currency, $unvoted->AmountOut) : 0;
                         $VoucherH['voucher_AmountIn']          = $unvoted->AmountIn  > 0 ? exchange::convertToLocal($unvoted->Currency, $unvoted->AmountIn)  : 0;

--- a/modules/bank/model/bank.class.php
+++ b/modules/bank/model/bank.class.php
@@ -1032,6 +1032,13 @@ class framework_logic_bank {
                         continue;
                     }
 
+                    $has_foreign_invoice = false;
+                    foreach ($relations as $rel) {
+                        if($rel["Currency"] != exchange::getLocalCurrency()) {
+                            $has_foreign_invoice = true;
+                        }
+                    }
+
                     //$VoucherH['voucher_InvoiceID'] = implode(',', $relations_invoices);
 
                     $accounting->insert_voucher_line(
@@ -1047,9 +1054,12 @@ class framework_logic_bank {
                     $FBVoucherH['voucher_CarID']         = $unvoted->CarID;
                     $FBVoucherH['voucher_DepartmentID']  = $unvoted->DepartmentID;
                     $FBVoucherH['voucher_Quantity']      = $unvoted->ResultQuantity;
-                    $FBVoucherH['voucher_VAT']           = $unvoted->VAT;
+                    $FBVoucherH['voucher_Vat']           = $unvoted->VAT;
 
                     foreach($relations as $rel) {
+                        // Skip creating the reason voucher if reason is currency difference.
+                        // After conversion, real difference is automatically generated.
+                        if($has_foreign_invoice && $rel["FakturabankBankTransactionAccountID"] == 90) continue;
 
                         if($rel['InvoiceType'] == 'incoming') {
                             $accountplan_row = $fbbank->find_account_plan_type(
@@ -1071,8 +1081,20 @@ class framework_logic_bank {
                                 if ($this->debug) printf("Adding normal Incoming\n");
                                 $FBVoucherH['voucher_AccountPlanID'] = $accountplan_row->AccountPlanID;
 
-                                $FBVoucherH['voucher_AmountOut']     = $rel['Amount'];
-                                $FBVoucherH['voucher_AmountIn']      = 0;
+                                if($rel['Currency'] == exchange::getLocalCurrency()) {
+                                    $FBVoucherH['voucher_AmountOut']         = $rel['Amount'];
+                                    $FBVoucherH['voucher_AmountIn']          = 0;
+                                    // reset foreign currency fields if this voucher should be in local currency
+                                    $FBVoucherH['voucher_ForeignCurrencyID'] = null;
+                                    $FBVoucherH['voucher_ForeignAmount']     = 0;
+                                    $FBVoucherH['voucher_ForeignConvRate']   = 0;
+                                } else {
+                                    $FBVoucherH['voucher_ForeignCurrencyID'] = $rel['Currency'];
+                                    $FBVoucherH['voucher_ForeignAmount']     = $rel['Amount'];
+                                    $FBVoucherH['voucher_ForeignConvRate']   = exchange::getConversionRate($rel['Currency']);
+                                    $FBVoucherH['voucher_AmountOut']         = exchange::convertToLocal($rel['Currency'], $rel['Amount']);
+                                    $FBVoucherH['voucher_AmountIn']          = 0;
+                                }
 
                                 $FBVoucherH['voucher_InvoiceID']     = $rel['InvoiceNumber'];
                                 $FBVoucherH['voucher_KID']           = $rel['KID'];
@@ -1101,8 +1123,20 @@ class framework_logic_bank {
                                 if ($this->debug) printf("Adding normal Outgoing\n");
                                 $FBVoucherH['voucher_AccountPlanID'] = $accountplan_row->AccountPlanID;
 
-                                $FBVoucherH['voucher_AmountOut']     = $rel['Amount'];
-                                $FBVoucherH['voucher_AmountIn']      = 0;
+                                if($rel['Currency'] == exchange::getLocalCurrency()) {
+                                    $FBVoucherH['voucher_AmountOut']         = $rel['Amount'];
+                                    $FBVoucherH['voucher_AmountIn']          = 0;
+                                    // reset foreign currency fields if this voucher should be in local currency
+                                    $FBVoucherH['voucher_ForeignCurrencyID'] = null;
+                                    $FBVoucherH['voucher_ForeignAmount']     = 0;
+                                    $FBVoucherH['voucher_ForeignConvRate']   = 0;
+                                } else {
+                                    $FBVoucherH['voucher_ForeignCurrencyID'] = $rel['Currency'];
+                                    $FBVoucherH['voucher_ForeignAmount']     = $rel['Amount'];
+                                    $FBVoucherH['voucher_ForeignConvRate']   = exchange::getConversionRate($rel['Currency']);
+                                    $FBVoucherH['voucher_AmountOut']         = exchange::convertToLocal($rel['Currency'], $rel['Amount']);
+                                    $FBVoucherH['voucher_AmountIn']          = 0;
+                                }
 
                                 $FBVoucherH['voucher_InvoiceID']     = $rel['InvoiceNumber'];
                                 $FBVoucherH['voucher_KID']           = $rel['KID'];
@@ -1152,6 +1186,15 @@ class framework_logic_bank {
                             }
                         }
                     }
+
+                    // In case that this journal had a foreign currency invoices, we should check if there is difference
+                    // after currency conversion between bank transaction and invoice amounts, and fix it.
+                    if($has_foreign_invoice) {
+                        if($result_motkonto_for_currency_difference = $accounting->get_accountplan_object($FBVoucherH['voucher_AccountPlanID'])->MotkontoResultat1) {
+                            $FBVoucherH['voucher_AccountPlanID'] = $result_motkonto_for_currency_difference;
+                        }
+                        $accounting->correct_journal_balance($FBVoucherH, $FBVoucherH['voucher_JournalID'], $this->VoucherType);
+                    }
                 }
                 ####################################################################################
                 else if($unvoted->ReskontroAccountPlanID && $unvoted->ResultAccountPlanID) {
@@ -1178,7 +1221,7 @@ class framework_logic_bank {
                     $VoucherH['voucher_ProjectID']          = $unvoted->ProjectID;
                     $VoucherH['voucher_DepartmentID']       = $unvoted->DepartmentID;
                     $VoucherH['voucher_Quantity']           = $unvoted->ResultQuantity;
-                    $VoucherH['voucher_VAT']                = $unvoted->VAT;
+                    $VoucherH['voucher_Vat']                = $unvoted->VAT;
 
                     $VoucherH = $this->SwitchSideAmount($VoucherH);
                     $accounting->insert_voucher_line(array('post'=> $VoucherH, 'accountplanid' => $VoucherH['voucher_AccountPlanID'], 'VoucherType'=> $this->VoucherType, 'comment' => 'Fra bankavstemming'));
@@ -1189,6 +1232,18 @@ class framework_logic_bank {
                     ############
                     #1.st line
                     $VoucherH['voucher_AccountPlanID']       = $this->AccountPlanID;
+
+                    if($unvoted->Currency == exchange::getLocalCurrency()) {
+                        $VoucherH['voucher_AmountOut']         = $unvoted->AmountOut;
+                        $VoucherH['voucher_AmountIn']          = $unvoted->AmountIn;
+                    } else {
+                        $amount = $unvoted->AmountIn > 0 ? $unvoted->AmountIn : $unvoted->AmountOut;
+                        $VoucherH['voucher_ForeignCurrencyID'] = $unvoted->Currency;
+                        $VoucherH['voucher_ForeignAmount']     = $amount;
+                        $VoucherH['voucher_ForeignConvRate']   = exchange::getConversionRate($unvoted->Currency);
+                        $VoucherH['voucher_AmountOut']         = $unvoted->AmountOut > 0 ? exchange::convertToLocal($unvoted->Currency, $unvoted->AmountOut) : 0;
+                        $VoucherH['voucher_AmountIn']          = $unvoted->AmountIn  > 0 ? exchange::convertToLocal($unvoted->Currency, $unvoted->AmountIn)  : 0;
+                    }
 
                     //else
                     {
@@ -1214,7 +1269,7 @@ class framework_logic_bank {
                     $VoucherH['voucher_ProjectID']          = $unvoted->ProjectID;
                     $VoucherH['voucher_DepartmentID']       = $unvoted->DepartmentID;
                     $VoucherH['voucher_Quantity']           = $unvoted->ResultQuantity;
-                    $VoucherH['voucher_VAT']                = $unvoted->VAT;
+                    $VoucherH['voucher_Vat']                = $unvoted->VAT;
 
                     $VoucherH = $this->SwitchSideAmount($VoucherH);
                     $accounting->insert_voucher_line(array('post' => $VoucherH, 'accountplanid' => $VoucherH['voucher_AccountPlanID'], 'VoucherType'=> $this->VoucherType, 'comment' => 'Fra bankavstemming'));

--- a/modules/exchange/model/exchange.class.php
+++ b/modules/exchange/model/exchange.class.php
@@ -245,6 +245,7 @@ class exchange {
 	 * @return string HTML form inside a div block. Div is initially hidden (display:none)
 	 */
 	function getFormHeaderCurrencyDropdown($voucher) {
+        global $_lib;
         $voucher_id = $voucher->VoucherID;
 
         if ($voucher_id == "") {
@@ -287,9 +288,9 @@ class exchange {
         $block_return = 'onKeyPress="return disableEnterKey(event)"';
         $ch_curr  .= '<div class="vouchercurrencyheaderwrapper" id="voucher_currency_div_'. $voucher_id_text .'" style="display:inline; padding: 5px; border: 1px solid grey;">';
         $ch_curr .= '<form method="post" name="voucher_global">';
-        $ch_curr .= 'Valuta: <select class="currency_id" name="voucher.ForeignCurrencyID" ' . $block_return . ' onchange="onCurrencyChange(this)">'. $select_options .'"</select>';
+        $ch_curr .= 'Valuta: <select class="currency_id" name="voucher.ForeignCurrencyID" ' . $block_return . ' onchange="onCurrencyChange(this, true)">'. $select_options .'"</select>';
         $ch_curr .= '<span class="currency_field" '. ($currency_is_hidden ? 'style="display: none;"' : '') .'>';
-        $ch_curr .= 'Kurs: <input class="number currency_rate" type="text" name="voucher.ForeignConvRate" size="10" onchange="this.value=toAmountString(toNumber(this.value))" value="'. str_replace(".", ",", (string)(round($voucher_foreign_rate, 4))) .'" ' . $block_return . ' /> =100' . self::getLocalCurrency();
+        $ch_curr .= 'Kurs: <input class="number currency_rate" type="text" name="voucher.ForeignConvRate" size="10" onchange="this.value=toAmountString(toNumber(this.value), 4)" value="'. $_lib['format']->Amount(array('value' => $voucher_foreign_rate, 'decimals' => 4, 'return' => 'value')) .'" ' . $block_return . ' /> =100' . self::getLocalCurrency();
         $ch_curr .= ' <a href="#" onclick="exchangeFindRate(this)" style="display: inline">finn kurs </a>';
         $ch_curr .= '<input class="number" type="hidden" name="voucher.VoucherID" value="'. $voucher_id .'" />';
         $ch_curr .= '<input type="hidden" name="action_postmotpost_save_currency" value="1" />';

--- a/modules/exchange/model/exchange.class.php
+++ b/modules/exchange/model/exchange.class.php
@@ -289,7 +289,7 @@ class exchange {
         $ch_curr .= '<form method="post" name="voucher_global">';
         $ch_curr .= 'Valuta: <select class="currency_id" name="voucher.ForeignCurrencyID" ' . $block_return . ' onchange="onCurrencyChange(this)">'. $select_options .'"</select>';
         $ch_curr .= '<span class="currency_field" '. ($currency_is_hidden ? 'style="display: none;"' : '') .'>';
-        $ch_curr .= 'Rate: <input class="number currency_rate" type="text" name="voucher.ForeignConvRate" size="10" onchange="this.value=toAmountString(toNumber(this.value))" value="'. str_replace(".", ",", (string)(round($voucher_foreign_rate, 4))) .'" ' . $block_return . ' /> =100' . self::getLocalCurrency();
+        $ch_curr .= 'Kurs: <input class="number currency_rate" type="text" name="voucher.ForeignConvRate" size="10" onchange="this.value=toAmountString(toNumber(this.value))" value="'. str_replace(".", ",", (string)(round($voucher_foreign_rate, 4))) .'" ' . $block_return . ' /> =100' . self::getLocalCurrency();
         $ch_curr .= ' <a href="#" onclick="exchangeFindRate(this)" style="display: inline">finn kurs </a>';
         $ch_curr .= '<input class="number" type="hidden" name="voucher.VoucherID" value="'. $voucher_id .'" />';
         $ch_curr .= '<input type="hidden" name="action_postmotpost_save_currency" value="1" />';

--- a/modules/fakturabank/model/fakturabank.class.php
+++ b/modules/fakturabank/model/fakturabank.class.php
@@ -1547,7 +1547,7 @@ class lodo_fakturabank_fakturabank {
                         if ($is_foreign) {
                             $datalineH['UnitCostPrice'] = exchange::convertToLocal($InvoiceO->DocumentCurrencyCode, $CustPrice);
                             $datalineH['ForeignCurrencyID'] = $InvoiceO->DocumentCurrencyCode;
-                            $datalineH['ForeignAmount']     = (float)$CustPrice;
+                            $datalineH['ForeignAmount']     = (float)$line->LineExtensionAmount + $line->TaxTotal->TaxAmount;
                             $datalineH['ForeignConvRate']   = $conversion_rate;
                         } else {
                             $datalineH['UnitCostPrice'] = $CustPrice;

--- a/modules/fakturabank/model/fakturabankvoting.class.php
+++ b/modules/fakturabank/model/fakturabankvoting.class.php
@@ -772,7 +772,11 @@ class lodo_fakturabank_fakturabankvoting {
                         }
                         $dataH['Type'] = $relation->{'type'};
                         $dataH['Amount'] = $relation->{'amount'};
-                        $dataH['Currency'] = $transaction->{"currency"}; // should be relation currency
+                        if(!empty($relation->{"invoice-currency"})) {
+                            $dataH['Currency'] = $relation->{"invoice-currency"};
+                        } else {
+                            $dataH['Currency'] = $transaction->{"currency"};
+                        }
                         $dataH['TransactionAmount'] = $transaction->amount;
                         $dataH['TransactionCurrency'] = $transaction->{"currency"};
                         $dataH['FakturabankBankTransactionAccountID'] = $relation->{'bank-transaction-account-id'};

--- a/modules/journal/view/edit.php
+++ b/modules/journal/view/edit.php
@@ -137,6 +137,8 @@ elseif($balance < 0)
   $class1 = "creditred";
 }
 
+$print_currency_inputs = $voucherHead->ForeignCurrencyID != '';
+
 ##############################################################
 #Get accountplan info
 
@@ -404,7 +406,7 @@ $acctmp = $accounting->get_accountplan_object($voucher_input->AccountPlanID);
     <th>Valuta</th>
     <th>I<u>n</u>n</th>
     <th>U<u>t</u></th>
-    <th>Rate</th>
+    <th>Kurs</th>
     <th><u>M</u>VA</th>
     <th>M<u>e</u>ngde</th>
     <th>A<u>v</u>d.</th>
@@ -427,7 +429,7 @@ $acctmp = $accounting->get_accountplan_object($voucher_input->AccountPlanID);
     </td>
 <? print $voucher_gui->creditdebitfield($AmountField, $accountplan, $voucher_input->AmountIn, $voucher_input->AmountOut, !$period_open) ?>
     <? //print $voucher_gui->currency($voucherHead, $accountplan, $vb, $class) ?>
-<? print $voucher_gui->currency2($voucherHead) ?>
+<? print $voucher_gui->currency2($voucherHead, $print_currency_inputs) ?>
 <td><? print $voucher_gui->vat($voucherHead, $accountplan, $VAT, $oldVatID, $voucher_input->VatID, $voucher_input->VatPercent, !$period_open) ?></td>
     <td><? if($accountplan->EnableQuantity)   { ?><input class="voucher" type="text" size="5"  tabindex="<? if($rowCount>1) { print ''; } else { print $tabindex++; } ?>" name="voucher.Quantity" accesskey="Q" value="<? print $_lib['format']->Amount(array('decimals' => 3, 'value' => $voucherHead->Quantity, 'return' => 'value')) ?>"><? } ?></td>
     <td>
@@ -640,7 +642,7 @@ while($voucher = $_lib['db']->db_fetch_object($result_voucher) and $rowCount>0) 
       <? //print $voucher_gui->currency($voucherHead, $accountplan, $vb, $class1) ?>
       <!--<td></td><td></td><td></td><td></td>-->
       <? $currency_is_editable = $voucher->DisableAutoVat != 1; ?>
-      <? print $voucher_gui->currency2($voucher, $currency_is_editable) // disable currency for nonhead lines ?>
+      <? print $voucher_gui->currency2($voucher, $currency_is_editable && $print_currency_inputs) // disable currency for nonhead lines ?>
       <td><? print $voucher_gui->vat($voucher, $accountplan, $VAT, $oldVatID, $VatID, $VatPercent, !$period_open) ?></td>
       <td><? if($accountplan->EnableQuantity) { if ($voucher->DisableAutoVat != 1) { ?><input class="voucher" type="text" size="5"  tabindex="<? print $tabindex++; ?>" accesskey="Q" name="voucher.Quantity" value="<? print $_lib['format']->Amount(array('decimals' => 3, 'value' => $voucher->Quantity, 'return' => 'value')); ?>"><? } } ?></td>
       <td><? if($accountplan->EnableDepartment) { ?><? $_lib['form2']->department_menu2(array('table' => $db_table, 'field' => 'DepartmentID', 'value' => $voucher->DepartmentID, 'tabindex' => $tabindex++, 'accesskey' => 'V')); } ?></td>

--- a/modules/journal/view/edit.php
+++ b/modules/journal/view/edit.php
@@ -137,7 +137,7 @@ elseif($balance < 0)
   $class1 = "creditred";
 }
 
-$print_currency_inputs = $voucherHead->ForeignCurrencyID != '';
+$print_currency_inputs = $voucherHead->ForeignCurrencyID != '' || is_null($voucherHead->VoucherID);
 
 ##############################################################
 #Get accountplan info

--- a/modules/journal/view/edit.php
+++ b/modules/journal/view/edit.php
@@ -211,6 +211,9 @@ print $_lib['sess']->doctype ?>
 #choose = search fopr KID
 // print "Hit2,5<br>";
 
+$message = $_lib['message']->get();
+print $message ? $message.'<br>' : '';
+
 if (!$_REQUEST['action_journal_kidsearch'])
 {
 
@@ -289,7 +292,18 @@ if(!$period_open) {
 
 <br />
 <br />
-
+<form id="hidden_currency_form" action="<? print $MY_SELF ?>" method="post">
+    <? print $_lib['form3']->hidden(array('name' => 'type'              , 'value' => $voucher_input->type)) ?>
+    <? print $_lib['form3']->hidden(array('name' => 'voucher.VoucherID' , 'value' => $voucherHead->VoucherID)) ?>
+    <? print $_lib['form3']->hidden(array('name' => 'voucher.JournalID' , 'value' => $voucher_input->JournalID)) ?>
+    <? print $_lib['form3']->hidden(array('name' => 'AccountLineID'  , 'value' => $voucher_input->AccountLineID)) ?>
+    <? print $_lib['form3']->hidden(array('name' => 'VoucherType'       , 'value' => $voucher_input->VoucherType)) ?>
+    <? print $_lib['form3']->hidden(array('name' => 'view_mvalines'     , 'value' => $view_mvalines)) ?>
+    <? print $_lib['form3']->hidden(array('name' => 'view_linedetails'  , 'value' => $view_linedetails)) ?>
+    <input type="hidden" name="action_postmotpost_save_currency" value="1" />
+    <input class="hiddenForeignCurrencyID" type="hidden" name="voucher.ForeignCurrencyID" value="" />
+    <input class="hiddenForeignConvRate" type="hidden" name="voucher.ForeignConvRate" value="" />
+</form>
 <form class="voucher" name="<? print $form_name2 ?>" action="<? print $MY_SELF ?>" method="post">
     <? print $_lib['form3']->hidden(array('name' => 'type'              , 'value' => $voucher_input->type)) ?>
     <? print $_lib['form3']->hidden(array('name' => 'voucher.VoucherID' , 'value' => $voucherHead->VoucherID)) ?>
@@ -387,9 +401,10 @@ $acctmp = $accounting->get_accountplan_object($voucher_input->AccountPlanID);
     <th>Debet</th>
     <th>Kredit</th>
     <th>Saldo</th>
-    <th></th>
+    <th>Valuta</th>
     <th>I<u>n</u>n</th>
     <th>U<u>t</u></th>
+    <th>Rate</th>
     <th><u>M</u>VA</th>
     <th>M<u>e</u>ngde</th>
     <th>A<u>v</u>d.</th>
@@ -609,8 +624,6 @@ while($voucher = $_lib['db']->db_fetch_object($result_voucher) and $rowCount>0) 
     <input type="hidden" name="voucher.VoucherDateOld"   value="<? print $voucher->VoucherDate ?>" />
     <input type="hidden" name="view_mvalines"         value="<? print $view_mvalines ?>" />
     <input type="hidden" name="view_linedetails"      value="<? print $view_linedetails ?>" />
-    <input type="hidden" name="voucher.ForeignCurrencyID"      value="<? print $voucher->ForeignCurrencyID ?>" />
-    <input type="hidden" name="voucher.ForeignConvRate"      value="<? print $voucher->ForeignConvRate ?>" />
 
 
     <tr class="<? print $row_class ?> voucher">
@@ -626,7 +639,8 @@ while($voucher = $_lib['db']->db_fetch_object($result_voucher) and $rowCount>0) 
       <? print $voucher_gui->creditdebitfield($AmountField, $accountplan, $voucher->AmountIn, $voucher->AmountOut, !$period_open) ?>
       <? //print $voucher_gui->currency($voucherHead, $accountplan, $vb, $class1) ?>
       <!--<td></td><td></td><td></td><td></td>-->
-      <?  print $voucher_gui->currency2($voucher) // disable currency for nonhead lines ?>
+      <? $currency_is_editable = $voucher->DisableAutoVat != 1; ?>
+      <? print $voucher_gui->currency2($voucher, $currency_is_editable) // disable currency for nonhead lines ?>
       <td><? print $voucher_gui->vat($voucher, $accountplan, $VAT, $oldVatID, $VatID, $VatPercent, !$period_open) ?></td>
       <td><? if($accountplan->EnableQuantity) { if ($voucher->DisableAutoVat != 1) { ?><input class="voucher" type="text" size="5"  tabindex="<? print $tabindex++; ?>" accesskey="Q" name="voucher.Quantity" value="<? print $_lib['format']->Amount(array('decimals' => 3, 'value' => $voucher->Quantity, 'return' => 'value')); ?>"><? } } ?></td>
       <td><? if($accountplan->EnableDepartment) { ?><? $_lib['form2']->department_menu2(array('table' => $db_table, 'field' => 'DepartmentID', 'value' => $voucher->DepartmentID, 'tabindex' => $tabindex++, 'accesskey' => 'V')); } ?></td>
@@ -665,8 +679,8 @@ while($voucher = $_lib['db']->db_fetch_object($result_voucher) and $rowCount>0) 
     <td align="right"><? print $_lib['format']->Amount($totalAmountIn) ?></td>
     <td align="right"><? print $_lib['format']->Amount($totalAmountOut) ?></td>
     <td colspan="2"></td>
-    <td align="right"><? print $totalForeignCurrency ." ". $_lib['format']->Amount($totalForeignAmountIn) ?></td>
-    <td align="right"><? print $totalForeignCurrency ." ". $_lib['format']->Amount($totalForeignAmountOut) ?></td>
+    <td align="right"></td>
+    <td align="right"></td>
   <td colspan="10" align="right">
   <? if($_lib['sess']->get_person('AccessLevel') >= 2) {
        if($accounting->is_valid_accountperiod($voucher_input->VoucherPeriod, $_lib['sess']->get_person('AccessLevel'))) { ?>

--- a/modules/journal/view/record.inc
+++ b/modules/journal/view/record.inc
@@ -16,7 +16,6 @@ $voucher_input      = new framework_logic_voucherinput($_REQUEST);
 global $_lib;
 $result = $_lib['db']->db_query('SELECT * FROM voucher WHERE JournalID = ' . $voucher_input->JournalID . ' LIMIT 1');
 $voucher_current = $_lib['db']->db_fetch_assoc($result);
-if (($voucher_input->ForeignCurrencyID != $voucher_current['ForeignCurrencyID']) || ($voucher_input->ForeignConvRate != $voucher_current['ForeignConvRate'])) exchange::updateJournalForeignCurrency();
 
 // Log warning (to logapplication table) if some required fields are not set
 $res = var_export($_REQUEST, true);
@@ -298,7 +297,7 @@ elseif(($voucher_input->action['voucher_update'] || $voucher_input->action['vouc
 
 	#print_r($voucher_input->request('voucher_update'));
 
-    $accounting->update_voucher_line_smart($voucher_input->request('voucher_update'), $voucher_input->VoucherIDOld, 'record');
+    $accounting->update_voucher_line_smart($voucher_input->request('voucher_update'), $voucher_input->VoucherIDOld, 'record', $_REQUEST['voucher_VoucherIsInOrOut']);
 
     #print "<h2>Test2</h2>";
     #Update hovedbokskonto for this postering, it may have changed

--- a/modules/journal/view/record.inc
+++ b/modules/journal/view/record.inc
@@ -315,7 +315,7 @@ if(($voucher_input->action['voucher_update'] or $voucher_input->action['voucher_
         $accounting->voucher_to_hovedbok_auto($voucher_input->AccountPlanID, $voucher_input->request('voucher_to_hovedbok_auto'), $voucher_input->VoucherIDOld);
 
         $accounting->delete_credit_debit_zero_lines($voucher_input->JournalID, $voucher_input->VoucherType); //#Dette blir feil bla nŒr vi legger til ny linje
-        $accounting->correct_journal_balance($voucher_input->request('correct_journal_balance'), $voucher_input->JournalID, $voucher_input->VoucherType);
+        $accounting->correct_journal_balance($voucher_input->request('correct_journal_balance'), $voucher_input->JournalID, $voucher_input->VoucherType, $voucher_input->action['voucher_new']);
 
         //#We only do this if the user has clicked new or update
         //#################################################################################################################

--- a/modules/postmotpost/view/list.php
+++ b/modules/postmotpost/view/list.php
@@ -136,9 +136,9 @@ if(count($postmotpost->voucherH) > 0 || count($postmotpost->hidingAccounts) > 0)
                 <th class="sub">Periode</th>
                 <th class="sub align-right">Inn</th>
                 <th class="sub align-right">Ut</th>
-                <th class="sub">Valuta</th>
-                <th class="sub">Valuta</th>
-                <th class="sub">Kurs</th>
+                <th class="sub align-right">Valuta</th>
+                <th class="sub align-right">Valuta</th>
+                <th class="sub align-right">Kurs</th>
                 <th class="sub">MVA%</th>
                 <th class="sub">Mengde</th>
                 <th class="sub">Avd.</th>

--- a/modules/postmotpost/view/list.php
+++ b/modules/postmotpost/view/list.php
@@ -136,9 +136,9 @@ if(count($postmotpost->voucherH) > 0 || count($postmotpost->hidingAccounts) > 0)
                 <th class="sub">Periode</th>
                 <th class="sub align-right">Inn</th>
                 <th class="sub align-right">Ut</th>
-                <th class="sub">Valuta inn</th>
-                <th class="sub">Valuta ut</th>
-                <th class="sub">Valuta/kurs</th>
+                <th class="sub">Valuta</th>
+                <th class="sub">Valuta</th>
+                <th class="sub">Kurs</th>
                 <th class="sub">MVA%</th>
                 <th class="sub">Mengde</th>
                 <th class="sub">Avd.</th>

--- a/modules/report/view/reskontrovoucherprint.php
+++ b/modules/report/view/reskontrovoucherprint.php
@@ -162,13 +162,13 @@ print $_lib['sess']->doctype ?>
     <th>Mengde</th>
     <th width="50" class="align-right">Debet</th>
     <th width="50" class="align-right">Kredit</th>
-    <th>MVA</th>
-    <th>Kode</th>
     <th width="50" class="align-right">Saldo</th>
-    <th width="50" class="align-right">V. inn</th>
-    <th width="50" class="align-right">V. ut</th>
-    <th width="50" class="align-right">V. saldo</th>
+    <th width="50" class="align-right">Valuta</th>
+    <th width="50" class="align-right">Valuta</th>
+    <th width="50" class="align-right">Saldo</th>
     <th>Tekst</th>
+    <th>Fakturano</th>
+    <th>KID</th>
     <th>Matchet med</th>
     <th class="noprint" class="align-right">Diff</th>
     <th class="noprint"></th>
@@ -188,7 +188,7 @@ print $_lib['sess']->doctype ?>
             if ($account) {
             ?>
 			<tr>
-				<td colspan="4">Periode sum</td>
+				<td colspan="2">Periode sum</td>
 				<td class="number"><? if($quantitysum > 0) print $_lib['format']->Amount($quantitysum); ?></td>
 				<td class="number"></td>
 				<td class="number"></td>
@@ -237,7 +237,6 @@ print $_lib['sess']->doctype ?>
                     <th class="sub number"></th>
                     <th class="sub number"><? print $accountplan->debittext ?></th>
                     <th class="sub number"><? print $accountplan->credittext ?></th>
-                    <th class="sub" colspan="2"></th>
                     <th class="sub number"><? print $_lib['format']->Amount($sum); ?></th>
                     <th class="sub number"></th>
                     <th class="sub number"></th>
@@ -247,11 +246,10 @@ print $_lib['sess']->doctype ?>
                     <th class="sub noprint" colspan="2"></th>
                 </tr>
 			          <tr>
-				            <td colspan="4">Periode sum</td>
+				            <td colspan="2">Periode sum</td>
                     <td class="number"></td>
                     <td class="number"></td>
                     <td class="number"></td>
-                    <td colspan="2"></td>
                     <td class="number"><? print $_lib['format']->Amount($sum); ?></td>
                     <td colspan="6"></td>
                     <td class="noprint" colspan="2"></td>
@@ -266,6 +264,8 @@ print $_lib['sess']->doctype ?>
 
             $quantitysum = 0;
             $saldo       = 0;
+
+            $foreign_saldo      = 0;
             
             #if account is reskontro, get its hovedboks konto
             $accountWork = $accounting->getHovedbokToAccount($account);
@@ -312,17 +312,16 @@ print $_lib['sess']->doctype ?>
                     <th class="sub number"><? if($quantity > 0) print $quantity; ?></th>
                     <th class="sub number align-right"><? print $accountplan->debittext ?></th>
                     <th class="sub number align-right"><? print $accountplan->credittext ?></th>
-                    <th class="sub" colspan="2"></th>
                     <th class="sub number align-right"><? print $_lib['format']->Amount($sumAccountH[$account]) ?></th>
-                    <th class="sub number align-right">V. inn</th>
-                    <th class="sub number align-right">V. ut</th>
-                    <th class="sub number align-right">V. saldo</th>
+                    <th class="sub number align-right">Valuta</th>
+                    <th class="sub number align-right">Valuta</th>
+                    <th class="sub number align-right">Saldo</th>
                 <? if ($voucher->ForeignCurrencyID && $voucher->ForeignAmount && $voucher->ForeignConvRate) { ?>
                     <th class="sub">Utenlandsk valuta</th>
                 <? } else { ?>
                     <th class="sub"></th>
                 <? } ?>
-                    <th class="sub" colspan="2"></th>
+                    <th class="sub" colspan="4"></th>
                     <th class="sub noprint"></th>
                 </tr>
             <?
@@ -337,7 +336,6 @@ print $_lib['sess']->doctype ?>
         #Foreign currency
         $foreign_amount_in  = 0;
         $foreign_amount_out = 0;
-        $foreign_saldo      = 0;
         if ($voucher->ForeignCurrencyID && $voucher->ForeignAmount && $voucher->ForeignConvRate) {
             $foreign_currency = "(".$voucher->ForeignCurrencyID ." ". $_lib['format']->Amount($voucher->ForeignAmount). " / ". $voucher->ForeignConvRate .") ";
             $foreign_currency_id = $voucher->ForeignCurrencyID;
@@ -361,13 +359,13 @@ print $_lib['sess']->doctype ?>
                 <td><? if($voucher->Quantity > 0)     { print $voucher->Quantity; } ?></td>
                 <td class="number"><nobr><? if($voucher->AmountIn > 0) { print $_lib['format']->Amount($voucher->AmountIn); } ?></nobr></td>
                 <td class="number"><nobr><? if($voucher->AmountOut > 0) { print $_lib['format']->Amount(-$voucher->AmountOut); } ?></nobr></td>
-                <td class="number"><? if($voucher->VatID > 0) { print "$voucher->Vat%"; } ?> </td>
-                <td class="number"><? if($voucher->VatID > 0) { print $voucher->VatID; } ?></td>
                 <td class="number"><nobr><? print $_lib['format']->Amount($saldo); ?></nobr></td>
                 <td class="number"><? ($voucher->AmountIn > 0) ? print $voucher->ForeignCurrencyID ." ". $_lib['format']->Amount($foreign_amount_in) : print '' ?></td>
-                <td class="number"><? ($voucher->AmountOut > 0) ? print $voucher->ForeignCurrencyID ." ". $_lib['format']->Amount($foreign_amount_out) : print '' ?></td>
+                <td class="number"><? ($voucher->AmountOut > 0) ? print $voucher->ForeignCurrencyID ." ". $_lib['format']->Amount(-$foreign_amount_out) : print '' ?></td>
                 <td class="number"><? print $voucher->ForeignCurrencyID ." ". $_lib['format']->Amount($foreign_saldo) ?></td>
                 <td><? print $foreign_currency; print substr($voucher->Description,0,20); if(strlen($voucher->Description) > 20) print "..."; ?></td>
+                <td><? print $voucher->InvoiceID ?></td>
+                <td><? print $voucher->KID ?></td>
                 <td><?
                     $is_closed = !is_null($_lib['db']->get_row(array("query" => "SELECT * FROM voucherstruct WHERE Closed = 1 AND (ParentVoucherID = " . $voucher->VoucherID . " OR ChildVoucherID = " . $voucher->VoucherID . ")"))->VoucherStructID);
                     $match_number = $_lib['db']->get_row(array("query" => "SELECT MatchNumber FROM vouchermatch WHERE VoucherID = $voucher->VoucherID"))->MatchNumber;
@@ -404,27 +402,27 @@ print $_lib['sess']->doctype ?>
     }
     ?>
     <tr>
-        <th colspan="9"><? print "$reptype " ?></th>
+        <th colspan="7"><? print "$reptype " ?></th>
         <th class="number"><nobr><? print $_lib['format']->Amount($sumSaldoAll) ?></nobr></th>
         <th colspan="2"></th>
         <th class="number"><? print $foreign_currency_id ." ". $_lib['format']->Amount($foreign_saldo) ?></th>
-        <th colspan="4"></th>
+        <th colspan="6"></th>
     </tr>
         <tr>
-            <th colspan="9"><? print $selectedAccount->AccountPlanID . " " . $selectedAccount->AccountName ?></th>
+            <th colspan="7"><? print $selectedAccount->AccountPlanID . " " . $selectedAccount->AccountName ?></th>
             <th class="number"><nobr><? list($sumhoved, $quantity) = get_saldo($selectedAccount->AccountPlanID, $_fromperiod, $_lib['date']->get_next_period($_toperiod)); print $_lib['format']->Amount($sumhoved) ?></nobr></th>
             <th colspan="2"></th>
-            <th colspan="5"></th>
+            <th colspan="6"></th>
         </tr>
         <tr>
-            <th colspan="9"><? print "Differanse " ?></th>
+            <th colspan="7"><? print "Differanse " ?></th>
             <th class="number"><nobr>
             <?
             $sumdiff = $sumhoved - $sumSaldoAll;
             print $_lib['format']->Amount($sumdiff);
             ?></nobr></th>
             <th colspan="2"></th>
-            <th colspan="5"></th>
+            <th colspan="6"></th>
         </tr>
 </table>
 </form>

--- a/modules/report/view/reskontrovoucherprint.php
+++ b/modules/report/view/reskontrovoucherprint.php
@@ -167,7 +167,7 @@ print $_lib['sess']->doctype ?>
     <th width="50" class="align-right">Valuta</th>
     <th width="50" class="align-right">Saldo</th>
     <th>Tekst</th>
-    <th>Fakturano</th>
+    <th>Fakturanr</th>
     <th>KID</th>
     <th>Matchet med</th>
     <th class="noprint" class="align-right">Diff</th>
@@ -362,7 +362,7 @@ print $_lib['sess']->doctype ?>
                 <td class="number"><nobr><? print $_lib['format']->Amount($saldo); ?></nobr></td>
                 <td class="number"><? ($voucher->AmountIn > 0) ? print $voucher->ForeignCurrencyID ." ". $_lib['format']->Amount($foreign_amount_in) : print '' ?></td>
                 <td class="number"><? ($voucher->AmountOut > 0) ? print $voucher->ForeignCurrencyID ." ". $_lib['format']->Amount(-$foreign_amount_out) : print '' ?></td>
-                <td class="number"><? print $voucher->ForeignCurrencyID ." ". $_lib['format']->Amount($foreign_saldo) ?></td>
+                <td class="number"><? print $_lib['format']->Amount($foreign_saldo) ?></td>
                 <td><? print $foreign_currency; print substr($voucher->Description,0,20); if(strlen($voucher->Description) > 20) print "..."; ?></td>
                 <td><? print $voucher->InvoiceID ?></td>
                 <td><? print $voucher->KID ?></td>

--- a/modules/voucher/model/vouchergui.class.php
+++ b/modules/voucher/model/vouchergui.class.php
@@ -137,7 +137,7 @@ class framework_logic_vouchergui
         $currencies = exchange::getActiveCurrencies();
 
         if (!empty($currencies)) {
-            $in_or_out = ($voucher->AmountIn > 0 ? 'in' : ($voucher->AmountOut > 0 ? 'out' : ''));
+            $in_or_out = ($voucher->AmountIn > 0 ? 'in' : ($voucher->AmountOut > 0 ? 'out' : 'both'));
 
             $html = '';
             $html .= '<td><input type="hidden" name="voucher_VoucherIsInOrOut" value="'. $in_or_out .'"></td>';
@@ -161,29 +161,30 @@ class framework_logic_vouchergui
             $html .= '</td>';
 
             if($editable) {
-                $foreign_amount_input = $_lib['form3']->text(array('name' => 'voucher.ForeignAmount', 'value' => $_lib['format']->Amount($voucher->ForeignAmount), 'class' => 'number', 'OnChange' => 'this.value = toAmountString(toNumber(this.value))', 'width' => '12'));
+                $foreign_amount_input_in = $_lib['form3']->text(array('name' => 'voucher.ForeignAmountIn', 'value' => $_lib['format']->Amount($voucher->ForeignAmount), 'class' => 'number', 'OnChange' => "setForeignInOrOut(this, 'in');", 'width' => '12'));
+                $foreign_amount_input_out = $_lib['form3']->text(array('name' => 'voucher.ForeignAmountOut', 'value' => $_lib['format']->Amount($voucher->ForeignAmount), 'class' => 'number', 'OnChange' => "setForeignInOrOut(this, 'out');", 'width' => '12'));
             } else {
                 $foreign_amount_input = '<div style="width: 80px !important;">'. $_lib['format']->Amount($voucher->ForeignAmount) .'</div>';
             }
 
             #AmountIn
             $html .= '<td>'.'<div class="currency_field" style="'. ($is_foreign ? 'text-align: right;' : 'display: none;') .'">';
-            if($in_or_out == 'in') {
-                $html .= $foreign_amount_input;
+            if($in_or_out == 'in' || $in_or_out == 'both') {
+                $html .= $foreign_amount_input_in;
             };
             $html .= '</div>'.'</td>';
 
             #AmountOut
             $html .= '<td>'.'<div class="currency_field" style="'. ($is_foreign ? 'text-align: right;' : 'display: none;') .'">';
-            if($in_or_out == 'out') {
-                $html .= $foreign_amount_input;
+            if($in_or_out == 'out' || $in_or_out == 'both') {
+                $html .= $foreign_amount_input_out;
             };
             $html .= '</div>'.'</td>';
 
             if($editable) {
-                $html .= '<td>'.'<div class="currency_field" style="'. ($is_foreign ? '' : 'display: none;') .'">'.'<input class="number currency_rate" type="text" name="voucher.ForeignConvRate" size="10" value="'. $_lib['format']->Amount($voucher->ForeignConvRate) .'" onchange="this.value = toAmountString(toNumber(this.value))"> = 100'. exchange::getLocalCurrency() .'</div></td>';
+                $html .= '<td>'.'<div class="currency_field" style="'. ($is_foreign ? '' : 'display: none;') .'">'.'<input class="number currency_rate" type="text" name="voucher.ForeignConvRate" size="10" value="'. $_lib['format']->Amount(array('value' => $voucher->ForeignConvRate, 'decimals' => 4, 'return' => 'value')) .'" onchange="this.value = toAmountString(toNumber(this.value), 4)"> = 100'. exchange::getLocalCurrency() .'</div></td>';
             } else {
-                $html .= '<td style="text-align: right;">'. ($is_foreign ? $_lib['format']->Amount($voucher->ForeignConvRate) .' = 100NOK' : '') .'</td>';
+                $html .= '<td style="text-align: right;">'. ($is_foreign ? $_lib['format']->Amount(array('value' => $voucher->ForeignConvRate, 'decimals' => 4, 'return' => 'value')) .' = 100NOK' : '') .'</td>';
             }
         }
 


### PR DESCRIPTION
Only the last commit is relevant since this is based on bp/ehf_currency_rework branch.

- [x] journal.edit currency field should be displayed for a new invoice, when non-domestic currency is picked on a new journal (for example if you want to create one invoice on 10 EUR)
- [x] Display currency rate on journal.edit page with 4 decimal places

Should be rebased to master after #339 is merged